### PR TITLE
Wrapping canvas

### DIFF
--- a/src/matrix_effect/canvas/util.cljs
+++ b/src/matrix_effect/canvas/util.cljs
@@ -1,22 +1,10 @@
-(ns matrix-effect.canvas.util
-  (:require
-   [re-frame.core :as re-frame]))
-
-(re-frame/reg-cofx
- ::get-canvas
- (fn [cofx]
-   (assoc cofx :canvas (.getElementById js/document "canv"))))
+(ns matrix-effect.canvas.util)
 
 (defn draw-rectangle!
   [canvas color width height]
   (let [ctx (.getContext canvas "2d")]
     (aset ctx "fillStyle" color)
     (.fillRect ctx 0 0 width height)))
-
-(re-frame/reg-fx
- ::draw-rectangle
- (fn [[canvas color width height]]
-   (draw-rectangle! canvas color width height)))
 
 (defn draw-character!
   [canvas color char width height]

--- a/src/matrix_effect/canvas/util.cljs
+++ b/src/matrix_effect/canvas/util.cljs
@@ -7,7 +7,7 @@
  (fn [cofx]
    (assoc cofx :canvas (.getElementById js/document "canv"))))
 
-(defn draw-rectangle
+(defn draw-rectangle!
   [canvas color width height]
   (let [ctx (.getContext canvas "2d")]
     (aset ctx "fillStyle" color)
@@ -16,9 +16,9 @@
 (re-frame/reg-fx
  ::draw-rectangle
  (fn [[canvas color width height]]
-   (draw-rectangle canvas color width height)))
+   (draw-rectangle! canvas color width height)))
 
-(defn draw-character
+(defn draw-character!
   [canvas color char width height]
   (let [ctx (.getContext canvas "2d")]
     (aset ctx "fillStyle" color)

--- a/src/matrix_effect/canvas/util.cljs
+++ b/src/matrix_effect/canvas/util.cljs
@@ -19,7 +19,7 @@
    (draw-rectangle canvas color width height)))
 
 (defn draw-character
-  [canvas char color width height]
+  [canvas color char width height]
   (let [ctx (.getContext canvas "2d")]
     (aset ctx "fillStyle" color)
     (aset ctx "font" "15pt monospace")

--- a/src/matrix_effect/events.cljs
+++ b/src/matrix_effect/events.cljs
@@ -1,6 +1,5 @@
 (ns matrix-effect.events
   (:require
-   [matrix-effect.canvas.util :as canvas]
    [matrix-effect.dimensions :as dimensions]
    [matrix-effect.timer.util :as timer]
    [re-frame.core :as re-frame]))
@@ -16,16 +15,6 @@
    (let [random-char (fn [] (String/fromCharCode (* (rand) 128)))]
      (assoc cofx :rand-chars (repeatedly n random-char)))))
 
-
-(re-frame/reg-fx
- ::draw-frame
- (fn [[canvas y-pos chars]]
-   (canvas/draw-rectangle! canvas "#0001" dimensions/width dimensions/height)
-   (run!
-     (fn [[idx y]]
-       (let [x (* idx 20)]
-         (canvas/draw-character! canvas "#0F0" (nth chars idx) x y)))
-     (map-indexed vector y-pos))))
 
 (defn next-y-pos
   "Takes a `y-pos` seq and generates `y`s values (moving them 20px down) for
@@ -51,7 +40,7 @@
 
 (re-frame/reg-event-fx
  ::initialize
- (fn [{:keys [db canvas]} _]
+ (fn [{:keys [db]} _]
    (let [cols (dimensions/cols dimensions/width)]
      {:db                  (assoc db :y-pos (repeat cols 0))
       ::timer/new-interval [#(re-frame/dispatch [::next-frame]) 50]})))

--- a/src/matrix_effect/events.cljs
+++ b/src/matrix_effect/events.cljs
@@ -30,7 +30,7 @@
 (defn next-y-pos
   "Takes a `y-pos` seq and generates `y`s values (moving them 20px down) for
    the next frame. According to `rand-nums`, randomly resets the end of the
-   column if it's at least 100px high."
+   column if it's at least 60% full height."
   [y-pos rand-nums]
   (->> y-pos
        (map-indexed vector)

--- a/src/matrix_effect/events.cljs
+++ b/src/matrix_effect/events.cljs
@@ -24,7 +24,7 @@
    (run!
      (fn [[idx y]]
        (let [x (* idx 20)]
-         (canvas/draw-character canvas (nth chars idx) "#0F0" x y)))
+         (canvas/draw-character canvas "#0F0" (nth chars idx) x y)))
      (map-indexed vector y-pos))))
 
 (defn next-y-pos

--- a/src/matrix_effect/events.cljs
+++ b/src/matrix_effect/events.cljs
@@ -45,7 +45,9 @@
   (re-frame/inject-cofx ::random-numbers (dimensions/cols dimensions/width))
   (re-frame/inject-cofx ::random-chars (dimensions/cols dimensions/width))]
  (fn [{:keys [db] :as cofx} _]
-   {:db          (update db :y-pos next-y-pos (:rand-nums cofx))
+   {:db          (-> db
+                     (update :y-pos next-y-pos (:rand-nums cofx))
+                     (assoc :chars (:rand-chars cofx)))
     ::draw-frame [(:canvas cofx) (:y-pos db) (:rand-chars cofx)]}))
 
 
@@ -61,5 +63,5 @@
 (re-frame/reg-event-fx
  ::stop
  (fn [{db :db} _]
-   {:db                   (dissoc db :y-pos)
+   {:db                   (dissoc db :y-pos :chars)
     ::timer/stop-interval (get db :timeout-id)}))

--- a/src/matrix_effect/events.cljs
+++ b/src/matrix_effect/events.cljs
@@ -20,11 +20,11 @@
 (re-frame/reg-fx
  ::draw-frame
  (fn [[canvas y-pos chars]]
-   (canvas/draw-rectangle canvas "#0001" dimensions/width dimensions/height)
+   (canvas/draw-rectangle! canvas "#0001" dimensions/width dimensions/height)
    (run!
      (fn [[idx y]]
        (let [x (* idx 20)]
-         (canvas/draw-character canvas "#0F0" (nth chars idx) x y)))
+         (canvas/draw-character! canvas "#0F0" (nth chars idx) x y)))
      (map-indexed vector y-pos))))
 
 (defn next-y-pos

--- a/src/matrix_effect/events.cljs
+++ b/src/matrix_effect/events.cljs
@@ -41,24 +41,20 @@
 
 (re-frame/reg-event-fx
  ::next-frame
- [(re-frame/inject-cofx ::canvas/get-canvas)
-  (re-frame/inject-cofx ::random-numbers (dimensions/cols dimensions/width))
+ [(re-frame/inject-cofx ::random-numbers (dimensions/cols dimensions/width))
   (re-frame/inject-cofx ::random-chars (dimensions/cols dimensions/width))]
  (fn [{:keys [db] :as cofx} _]
-   {:db          (-> db
-                     (update :y-pos next-y-pos (:rand-nums cofx))
-                     (assoc :chars (:rand-chars cofx)))
-    ::draw-frame [(:canvas cofx) (:y-pos db) (:rand-chars cofx)]}))
+   {:db (-> db
+            (update :y-pos next-y-pos (:rand-nums cofx))
+            (assoc :chars (:rand-chars cofx)))}))
 
 
 (re-frame/reg-event-fx
  ::initialize
- [(re-frame/inject-cofx ::canvas/get-canvas)]
  (fn [{:keys [db canvas]} _]
    (let [cols (dimensions/cols dimensions/width)]
-     {:db                     (assoc db :y-pos (repeat cols 0))
-      ::canvas/draw-rectangle [canvas "#000" dimensions/width dimensions/height]
-      ::timer/new-interval    [#(re-frame/dispatch [::next-frame]) 50]})))
+     {:db                  (assoc db :y-pos (repeat cols 0))
+      ::timer/new-interval [#(re-frame/dispatch [::next-frame]) 50]})))
 
 (re-frame/reg-event-fx
  ::stop

--- a/src/matrix_effect/subs.cljs
+++ b/src/matrix_effect/subs.cljs
@@ -1,0 +1,22 @@
+(ns matrix-effect.subs
+  (:require
+   [re-frame.core :as re-frame]))
+
+(re-frame/reg-sub
+ ::y-pos
+ (fn [db]
+   (get db :y-pos)))
+
+(re-frame/reg-sub
+ ::chars
+ (fn [db]
+   (get db :chars)))
+
+
+(re-frame/reg-sub
+ ::elements
+ :<- [::y-pos]
+ :<- [::chars]
+ (fn [[y-pos chars] _]
+   (->> (interleave chars (iterate (partial + 20) 0) y-pos)
+        (partition 3))))

--- a/src/matrix_effect/views.cljs
+++ b/src/matrix_effect/views.cljs
@@ -1,13 +1,32 @@
 (ns matrix-effect.views
   (:require
+   [matrix-effect.canvas.util :as canvas.util]
    [matrix-effect.dimensions :as dimensions]
    [matrix-effect.events :as events]
    [matrix-effect.subs :as subs]
-   [re-frame.core :as re-frame]))
+   [re-frame.core :as re-frame]
+   [reagent.core :as reagent]
+   [reagent.dom :as rdom]))
+
+(defn canvas
+  [{:keys [width height]}]
+  (reagent/create-class
+    {:display-name "canv"
+     :reagent-render (fn [{:keys [width height]}]
+                       [:canvas {:width width, :height height}])
+     :component-did-mount (fn [comp]
+                            (let [canvas (rdom/dom-node comp)]
+                              (canvas.util/draw-rectangle! canvas "#000" width height)))
+     :component-did-update (fn [comp]
+                             (let [canvas   (rdom/dom-node comp)
+                                   elements (get (reagent/props comp) :elements)]
+                               (canvas.util/draw-rectangle! canvas "#0001" width height)
+                               (run! (partial apply canvas.util/draw-character! canvas "#0F0")
+                                     elements)))}))
 
 (defn main-panel []
   [:div
    [:h1 "The matrix-effect"]
-   [:canvas {:id     "canv"
-             :width  dimensions/width
-             :height dimensions/height}]])
+   (let [new-elements (re-frame/subscribe [::subs/elements])]
+     [canvas {:width dimensions/width, :height dimensions/height
+              :elements @new-elements}])])

--- a/src/matrix_effect/views.cljs
+++ b/src/matrix_effect/views.cljs
@@ -2,6 +2,7 @@
   (:require
    [matrix-effect.dimensions :as dimensions]
    [matrix-effect.events :as events]
+   [matrix-effect.subs :as subs]
    [re-frame.core :as re-frame]))
 
 (defn main-panel []


### PR DESCRIPTION
Although we are currently using re-frame, dividing pure components from the impure ones, modifying the `canvas` via
```
:matrix-effect.canvas.util/get-canvas ⟶
getElementById ⟶
:matrix-effect.canvas.util/draw-rectangle
```
(using coeffects, effects) not fully sticks with the re-frame's philosophy. It proposes that the data should be sended to views through subscriptions, and the new characters to paint on `canvas`, are at the end of the day, this kind of data.

Creates a wrapper to encapsulate the impurity of `canvas`, which now receives the new elements to be painted, and internally carry out the necessary processes to paint them. `:matrix-effect.events/draw-frame` effect is deprecated and instead `:matrix-effect.events/next-frame` now just updates the database with the new model.